### PR TITLE
add micro-rest and use new micro-graphql

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ In the area of open source, there's a lot of stuff happening around [ZEIT](https
 
 ### Boilerplates
 
+- [micro-rest](https://github.com/hyperfuse/micro-rest) - Easily deploy micro REST services.
+- [micro-graphql](https://github.com/hyperfuse/micro-graphql) - Easily deploy micro GraphQL services.
 - [now-go](https://github.com/amio/now-go) - Create & Deploy a personal tinyurl service in 1 minute.
 - [create-react-app-now](https://github.com/xkawi/create-react-app-now) - Easily deploy react.js applications with now.
-- [micro-graphql](https://github.com/timneutkens/micro-graphql) - Create an express-graphql server with Micro.
 - [create-micro](https://github.com/romuloalves/create-micro) - Create a basic micro-based service.
 
 ### API Clients

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ In the area of open source, there's a lot of stuff happening around [ZEIT](https
 - [micro-graphql](https://github.com/hyperfuse/micro-graphql) - Easily deploy micro GraphQL services.
 - [now-go](https://github.com/amio/now-go) - Create & Deploy a personal tinyurl service in 1 minute.
 - [create-react-app-now](https://github.com/xkawi/create-react-app-now) - Easily deploy react.js applications with now.
-- [create-micro](https://github.com/romuloalves/create-micro) - Create a basic micro-based service.
+- [micro-graphql](https://github.com/hyperfuse/micro-graphql) - Easily deploy micro GraphQL services. For an example of using GraphQL with Micro see [micro-graphql-example](https://www.github.com/timneutkens/micro-graphql)
 
 ### API Clients
 


### PR DESCRIPTION
I added 2 boilerplates made at the start-up I work at:
+ micro-rest - deploy REST API's in seconds
+ micro-graphql - it implements the old micro-graphql into an actual project to deploy graphql API's in seconds with micro.