### PR TITLE
add emails.now.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ In the area of open source, there's a lot of stuff happening around [ZEIT](https
 - [e.now.sh](https://e.now.sh/) - A microservice for serving, listing and searching for emoji
 - [f.now.sh](https://f.now.sh/) - A microservice for getting a flag icon by country code
 - [gif.now.sh](https://gif.now.sh) - A simple micro-service for Giphy's Translate API
+- [emails.now.sh](https://emails.now.sh) - Easily deploy an email delivery service to now
 
 ### Related Lists
 


### PR DESCRIPTION
This adds https://emails.now.sh, a `micro`-based service for delivering emails.