### PR TITLE
Add now-env to helpers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ In the area of open source, there's a lot of stuff happening around [ZEIT](https
 - [now-pipeline](https://github.com/bahmutov/now-pipeline) - Single command to deploy, run e2e tests and switch alias if tests pass.
 - [now-redirect](https://github.com/vdanchenkov/now-redirect) - Easily deploy a redirect like `www.domain.com` to `domain.com`.
 - [zeit-deployments](https://github.com/pranaygp/zeit-deployments) - Deploy a tiny next.js app to now that lists all your now deployments.
+- [now-env](https://github.com/sergiodxa/now-env) - Use now.json environment variables and secrets in development
 
 ### Libraries
 


### PR DESCRIPTION
**now-env** is a little helper to use `now.json` (and `package.json` now env key) to set environment variables in development. It also support secrest with a `now-secrets.json` file using the same secrets syntax as Now (`@key-name`).