### PR TITLE
Add platzi-now.now.sh to showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Take a look at [awesome-micro](https://github.com/amio/awesome-micro)! 😌
 - [emails.now.sh](https://emails.now.sh) - Easily deploy an email delivery service to now
 - [next-time.now.sh](https://next-time.now.sh) ([src](https://github.com/billymoon/next-time)) - A very minimal zeit themed clock (demonstrates isomorphic page rendering)  
 - [georgeo.now.sh](https://github.com/rmpato/georgeo) - A geocoding service with an API and a [web interface](https://georgeo.now.sh)
+- [platzi-now.now.sh](https://platzi-now.now.sh/) - A Next.js + Docker GraphQL server app deployed to Now.sh using alias path to compose them
 
 ### Related Lists
 


### PR DESCRIPTION
A Next.js + Docker GraphQL server app deployed to Now.sh using alias path to compose them.