### PR TITLE
Add a project to Now showcase

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,7 @@ Take a look at [awesome-micro](https://github.com/amio/awesome-micro)! 😌
 - [micro-medium-api.now.sh](https://micro-medium-api.now.sh/) - [📖](https://github.com/evenchange4/micro-medium-api) - Microservice for fetching the latest posts of Medium.
 - [now-swift-example.now.sh](https://now-swift-example.now.sh/) - [📖](https://github.com/aranajhonny/now-swift-example) - Example of using server-side Swift + the Kitura framework inside a Docker container deployed to now.sh.
 - [builderbook.org](https://builderbook.org/) - [📖](https://github.com/builderbook/builderbook) - Open source web app to write and host documentation or sell books. Deployed with Now and built with React, Material-UI, Next, Express, Mongoose, MongoDB.
+- [flash.now.sh](https://flash.now.sh/) - A minimal speed reading web app
 
 ### Related Lists
 


### PR DESCRIPTION
Hi!
I'd like to add [flash.now.sh](https://flash.now.sh) to Now showcase.
It's a tiny app that allows you to speed read text by rapidly showing words one by one.