### PR TITLE
Add `circleci-artifacts.now.sh`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -105,6 +105,7 @@ Take a look at [awesome-micro](https://github.com/amio/awesome-micro)! 😌
 - [vscode-now](https://github.com/lucaperret/vscode-now) - Create and manage your deployments and aliases within VS Code.
 - [releasebutler.now.sh](https://releasebutler.now.sh/) - Get releases & changelogs of popular frontend frameworks & libraries!
 - [carbon.now.sh](https://carbon.now.sh/) - Create and share beautiful images of your source code. Start typing or drop a file into the text area to get started.
+- [circleci-artifacts.now.sh](https://circleci-artifacts.now.sh/) - Permanent link for redirecting to your latest CircleCI build artifacts, so you could host binaries, documentation and other files right from your project's Circle CI jobs.
 
 ### Related Lists
 


### PR DESCRIPTION
Adds https://circleci-artifacts.now.sh ( https://github.com/Schniz/circleci_redirection ) to the list.
A simple service that redirects you to artifacts from the latest successful build (on a specific branch)